### PR TITLE
fix: type error in Items.tsx

### DIFF
--- a/src/utils/types/repoType.tsx
+++ b/src/utils/types/repoType.tsx
@@ -10,6 +10,13 @@ export interface Repository extends RepoType {
   user: UserType;
 }
 
+// returned data type
+export interface FetchData {
+  data: Repository[];
+  has_more: boolean;
+  page: number;
+}
+
 export interface RepoType {
   item_id: string;
   url: string;


### PR DESCRIPTION
增加了对热门和最近返回数据的类型约束
1. 在types中增加了FetchData类型
2. 返回数据是unknow类型，对其进行了类型收窄