### PR TITLE
fix(item): lang color arbitrary value not work

### DIFF
--- a/src/components/home/Item.tsx
+++ b/src/components/home/Item.tsx
@@ -54,7 +54,8 @@ const Item: NextPage<ItemProps> = ({ item }) => {
               <span className='pl-1 pr-1'>·</span>
               <span>
                 <span
-                  className={`relative box-border inline-block h-3 w-3 rounded-full border align-[-1px] bg-[${item.lang_color}]`}
+                  style={{ backgroundColor: `${item.lang_color}` }}
+                  className='relative box-border inline-block h-3 w-3 rounded-full border align-[-1px]'
                 ></span>
                 <span className='text-color-primary whitespace-nowrap pl-0.5'>
                   {item.primary_lang}


### PR DESCRIPTION
Tailwind 不能依赖于在客户端发生变化的任何类型的任意动态值。在这些情况下使用内联样式。
[arbitrary-value-support](https://v2.tailwindcss.com/docs/just-in-time-mode#arbitrary-value-support) 文档在这里。