### PR TITLE
fix: 调整了切换主题按钮样式

### DIFF
--- a/src/components/ThemeSwitch.tsx
+++ b/src/components/ThemeSwitch.tsx
@@ -39,7 +39,7 @@ export default function ThemeSwitch(props: ThemeSwitchProps) {
       aria-checked
       onClick={onToggle}
     >
-      <span className='absolute top-px left-px h-[16px] w-[16px] rounded-full bg-white shadow transition-all duration-300 dark:translate-x-[18px] dark:bg-gray-800'>
+      <span className='absolute top-px left-px h-[16px] w-[16px] rounded-full bg-white shadow transition-all duration-300 dark:translate-x-[calc(1.5rem-2px)] dark:bg-gray-800'>
         <span>
           <svg
             xmlns='http://www.w3.org/2000/svg'


### PR DESCRIPTION
我发现切换主题按钮样式有一些问题

调整之前：
![image](https://github.com/HelloGitHub-Team/geese/assets/74909529/80da17c4-2f25-44fe-91be-92b0e75aed36)

调整之后：
![image](https://github.com/HelloGitHub-Team/geese/assets/74909529/54a517fe-ef68-4286-a592-c5f06b54a406)

由于上面的按钮宽度是2.5rem padding是两个0.5rem border是两个1px，所以下面图标正确位移应该是`2.5rem - 0.5rem * 2 - 1px * 2`