### PR TITLE
feat: 增加点击添加标签的交互

### DIFF
--- a/src/components/dialog/GroupItem.tsx
+++ b/src/components/dialog/GroupItem.tsx
@@ -10,10 +10,12 @@ interface IProps {
   effectedTidList: string[];
   groupName: string;
   portalTagGroupsRef: MutableRefObject<PortalTagGroup[]>;
+  handleAddTag: (tid: string) => void;
 }
 
 const GroupItem = (props: IProps) => {
-  const { item, effectedTidList, groupName, portalTagGroupsRef } = props;
+  const { item, effectedTidList, groupName, portalTagGroupsRef, handleAddTag } =
+    props;
   const sortItemRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -36,12 +38,14 @@ const GroupItem = (props: IProps) => {
       };
     }
   }, [groupName, portalTagGroupsRef, effectedTidList]);
+
   return (
     <div
       ref={sortItemRef}
       className={`${
         effectedTidList.includes(item.tid) ? 'exist-tag flex opacity-30' : ''
       }`}
+      onClick={() => handleAddTag(item.tid)}
     >
       <div
         key={item.tid}

--- a/src/components/dialog/TagModal.tsx
+++ b/src/components/dialog/TagModal.tsx
@@ -67,6 +67,13 @@ export function TagModal({
     setTotal(tidList.length);
   };
 
+  const addTag = (tid: string) => {
+    if (effectedTidList.includes(tid)) return;
+    if (effectedTidList.length >= maxTotal) return;
+    const tidList = [...effectedTidList, tid];
+    setEffectedTidList(tidList);
+  };
+
   const removeTag = (tid?: string) => {
     if (tid) {
       const newTidList = effectedTidList.filter((f) => f !== tid);
@@ -158,6 +165,7 @@ export function TagModal({
                     effectedTidList={effectedTidList}
                     groupName={group.group_name}
                     portalTagGroupsRef={portalTagGroupsRef}
+                    handleAddTag={addTag}
                   />
                 ))}
               </div>,

--- a/src/components/dialog/TagModal.tsx
+++ b/src/components/dialog/TagModal.tsx
@@ -136,7 +136,7 @@ export function TagModal({
     <>
       <div onClick={openModal}>{children}</div>
       <BasicDialog
-        className='w-3/5 rounded-lg p-5'
+        className='w-10/12 xl:w-8/12 2xl:w-7/12 rounded-lg p-5'
         visible={isOpen}
         onClose={closeModal}
       >

--- a/src/components/dialog/TagModal.tsx
+++ b/src/components/dialog/TagModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   IoIosCloseCircleOutline,
   IoMdAddCircleOutline,
@@ -63,21 +63,22 @@ export function TagModal({
       (m) => (m as HTMLElement).dataset.tid ?? ''
     );
     setEffectedTidList(tidList);
-    setTotal(tidList.length);
   };
 
-  const addTag = (tid: string) => {
-    if (effectedTidList.includes(tid)) return;
-    if (effectedTidList.length >= maxTotal) return;
-    const tidList = [...effectedTidList, tid];
-    setEffectedTidList(tidList);
-  };
+  const addTag = useCallback(
+    (tid: string) => {
+      if (effectedTidList.includes(tid)) return;
+      if (effectedTidList.length >= maxTotal) return;
+      const tidList = [...effectedTidList, tid];
+      setEffectedTidList(tidList);
+    },
+    [effectedTidList]
+  );
 
   const removeTag = (tid?: string) => {
     if (tid) {
       const newTidList = effectedTidList.filter((f) => f !== tid);
       setEffectedTidList(newTidList);
-      setTotal(newTidList.length);
     }
   };
 

--- a/src/components/dialog/TagModal.tsx
+++ b/src/components/dialog/TagModal.tsx
@@ -4,7 +4,6 @@ import {
   IoMdAddCircleOutline,
   IoMdBulb,
 } from 'react-icons/io';
-import { VscChromeClose } from 'react-icons/vsc';
 import Sortable from 'sortablejs';
 
 import { useLoginContext } from '@/hooks/useLoginContext';
@@ -138,11 +137,13 @@ export function TagModal({
       <BasicDialog
         className='w-3/5 rounded-lg p-5'
         visible={isOpen}
-        hideClose={true}
         onClose={closeModal}
       >
-        <div className='ml-auto box-content w-6 pb-1 pl-4' onClick={closeModal}>
-          <VscChromeClose size={24} className='cursor-pointer text-gray-500' />
+        <div className='flex items-center mb-4 text-gray-500 dark:text-gray-200'>
+          <IoMdBulb />
+          <span className='text-sm'>
+            操作提示：点击或拖拽标签到右边侧为「选择」，拖拽已选标签可「排序」
+          </span>
         </div>
         <div className='flex flex-wrap'>
           <div className='w-2/3 pr-3'>
@@ -221,12 +222,6 @@ export function TagModal({
           </div>
         </div>
         <div className='mt-4 flex flex-row items-center gap-4 text-sm text-gray-500'>
-          <div className='flex items-center'>
-            <IoMdBulb />
-            <span className='dark:text-gray-200'>
-              操作提示：拖拽标签到右边侧为「选择」，拖拽已选标签可「排序」
-            </span>
-          </div>
           <div className='shrink grow' />
           <FeedbackModal feedbackType={1}>
             <div className='flex w-full cursor-pointer flex-row items-center rounded-lg border border-gray-200 bg-white hover:border-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:hover:border-blue-500'>


### PR DESCRIPTION
**1. 增加了点击左侧待选标签，追加到右侧暂存区域尾部的交互逻辑。**

**2. 将标签操作提示移动到上方并降低文字对比度，使其更容易被看到但又不会太醒目。**

前几天使用 HelloGithub 网站整理自己的标签时，按照以往的习惯点击添加标签，点了很多次发现没有反应，然后才在下面看到需要拖拽才能添加到右侧的暂存区域，感觉需要小小优化一下。

![image](https://github.com/HelloGitHub-Team/geese/assets/21002250/02f0f889-0d64-4d3c-a948-80c9c1dfe162)
